### PR TITLE
消息类别饼图中增加占比和数量的显示

### DIFF
--- a/wx-dump-ui/src/pages/Dashboard/Components/MsgCategory.tsx
+++ b/wx-dump-ui/src/pages/Dashboard/Components/MsgCategory.tsx
@@ -1,6 +1,7 @@
 import { msgTypeDistribution } from '@/services/Wechat/DashBoard';
 import { Pie } from '@ant-design/plots';
 import React, { useEffect, useState } from 'react';
+import {sum} from "@antfu/utils";
 
 const MsgCategory: React.FC = () => {
   const [data, setData] = useState<MsgTypeDistributionItem[]>([]);
@@ -24,7 +25,16 @@ const MsgCategory: React.FC = () => {
     colorField: 'type',
     radius: 0.9,
     tooltip: {
-      title: 'value',
+      title: 'type',
+      items:[{
+        field: 'value',
+        name: '数量',
+      },{
+        field: 'value',
+        valueFormatter: (d: number) => `${(d / sum(data.map(item => item.value)) * 100).toFixed(1) + '%'}`,
+        name: '占比',
+        color:''
+      },],
     },
     legend: {
       color: {


### PR DESCRIPTION
修正了消息类别饼图的显示内容：

![image](https://github.com/xuchengsheng/wx-dump-4j/assets/149303192/d0d10ead-fc45-4016-a594-d70afccef16f)
